### PR TITLE
write to /usr/bin instead of /usr/local/bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Your source directory must have a package.json for a properly generated
 * `description`
 * `homepage`
 
+Before packaging the provided binary is written to `/usr/bin` for it to be able
+to be executed globally once installed on a user's system.
+
 ```js
 const pkgDeb = require('pkg-deb')
 const path = require('path')

--- a/src/packager.js
+++ b/src/packager.js
@@ -141,9 +141,9 @@ PackageDebian.prototype.createStagingDir = async function () {
 PackageDebian.prototype.copyApplication = async function () {
   this.logger(`Copying application to ${this.stagingDir}`)
   await fs.ensureDir(this.stagingDir, '0755')
-  // because we are packaging a binary, we need to make sure it's bundled in
-  // /usr/local/bin
-  const executable = path.join(this.stagingDir, '/usr/local/bin', this.name)
+  // binary needs to live in /usr/bin (if any data needs to be present, it can
+  // be written to /usr/share.
+  const executable = path.join(this.stagingDir, '/usr/bin', this.name)
   await fs.copy(this.input, executable)
   await fs.chmod(executable, 0o755)
 }

--- a/test/packager.js
+++ b/test/packager.js
@@ -164,7 +164,7 @@ describe('Packager', function () {
     it('PackageDebian.prototype.copyApplication', async function () {
       await pkgDebian.createStagingDir()
       await pkgDebian.copyApplication()
-      const doesExist = await fs.pathExists(path.join(pkgDebian.stagingDir, '/usr/local/bin', pkgDebian.name))
+      const doesExist = await fs.pathExists(path.join(pkgDebian.stagingDir, '/usr/bin', pkgDebian.name))
       // eslint-disable-next-line
       expect(doesExist).to.be.true
     })


### PR DESCRIPTION
## Description
We should not be writing the binary to `/usr/local/bin` since the `local`
directory is considered to be the reponsibility of system administrator.
Instead, we ought to write the binary to just `/usr/bin`, and if any data
follows, `/usr/share`.

### Checklist
- [x] New tests and/or benchmarks are included
- [x] Documentation is changed or added


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)